### PR TITLE
szybsze ładowanie notatek i poprawki trybu zaznaczania

### DIFF
--- a/app/composables/useNotes.ts
+++ b/app/composables/useNotes.ts
@@ -294,7 +294,23 @@ export const useNotes = () => {
 
     const existingById = new Map(notes.value.map(note => [note.id, note]))
 
-    const memberships = await getUserMemberships(currentUserId)
+    // Memberships + personal files in parallel (both only need currentUserId)
+    const [memberships, personalResult] = await Promise.all([
+      getUserMemberships(currentUserId),
+      supabase
+        .from('files')
+        .select('id, object_id, group_id, uploaded_by, name, created_at')
+        .eq('uploaded_by', currentUserId)
+        .is('group_id', null)
+        .eq('file_type', 'note')
+        .order('created_at', { ascending: false })
+    ])
+
+    if (personalResult.error) {
+      console.error('Błąd pobierania notatek personalnych:', personalResult.error)
+      return
+    }
+
     const membershipGroupIds = memberships.map(membership => membership.group_id)
     const membershipMap = memberships.reduce<Record<string, MembershipRole>>((acc, membership) => {
       acc[membership.group_id] = membership.role
@@ -302,57 +318,38 @@ export const useNotes = () => {
     }, {})
     membershipRoleByGroup.value = membershipMap
 
+    // Groups + shared files in parallel (both depend on membershipGroupIds)
     let groupsById = new Map<string, GroupRecord>()
-    if (membershipGroupIds.length > 0) {
-      const { data: groupRows, error: groupsError } = await supabase
-        .from('groups')
-        .select('id, name, type')
-        .in('id', membershipGroupIds)
-
-      if (!groupsError) {
-        groupsById = new Map((groupRows || []).map(group => [group.id, group as GroupRecord]))
-      }
-    }
-
-    const { data: personalData, error: personalError } = await supabase
-      .from('files')
-      .select('id, object_id, group_id, uploaded_by, name, created_at')
-      .eq('uploaded_by', currentUserId)
-      .is('group_id', null)
-      .eq('file_type', 'note')
-      .order('created_at', { ascending: false })
-
-    if (personalError) {
-      console.error('Błąd pobierania notatek personalnych:', personalError)
-      return
-    }
-
     let sharedData: FileRecord[] = []
-    if (membershipGroupIds.length > 0) {
-      const { data: groupData, error: groupError } = await supabase
-        .from('files')
-        .select('id, object_id, group_id, uploaded_by, name, created_at')
-        .in('group_id', membershipGroupIds)
-        .eq('file_type', 'note')
-        .order('created_at', { ascending: false })
 
-      if (groupError) {
-        console.error('Błąd pobierania notatek współdzielonych:', groupError)
+    if (membershipGroupIds.length > 0) {
+      const [groupsResult, sharedResult] = await Promise.all([
+        supabase
+          .from('groups')
+          .select('id, name, type')
+          .in('id', membershipGroupIds),
+        supabase
+          .from('files')
+          .select('id, object_id, group_id, uploaded_by, name, created_at')
+          .in('group_id', membershipGroupIds)
+          .eq('file_type', 'note')
+          .order('created_at', { ascending: false })
+      ])
+
+      if (!groupsResult.error) {
+        groupsById = new Map((groupsResult.data || []).map(group => [group.id, group as GroupRecord]))
+      }
+      if (sharedResult.error) {
+        console.error('Błąd pobierania notatek współdzielonych:', sharedResult.error)
       } else {
-        sharedData = (groupData || []) as FileRecord[]
+        sharedData = (sharedResult.data || []) as FileRecord[]
       }
     }
 
     const mergedByObjectId = new Map<string, FileRecord>()
-    for (const row of [...sharedData, ...((personalData || []) as FileRecord[])]) {
-      if (!row.group_id && row.uploaded_by !== currentUserId) {
-        continue
-      }
-
-      if (row.group_id && !membershipMap[row.group_id]) {
-        continue
-      }
-
+    for (const row of [...sharedData, ...((personalResult.data || []) as FileRecord[])]) {
+      if (!row.group_id && row.uploaded_by !== currentUserId) continue
+      if (row.group_id && !membershipMap[row.group_id]) continue
       mergedByObjectId.set(row.object_id, row)
     }
 
@@ -391,12 +388,11 @@ export const useNotes = () => {
       }
     })
 
+    // Update uploader labels in background — notes are already visible
     const sharedNotes = notes.value.filter(note => note.visibility === 'shared')
-    await Promise.all(sharedNotes.map(async (note) => {
+    Promise.all(sharedNotes.map(async (note) => {
       const { data: uploaderRows, error: uploaderError } = await (supabase as any)
-        .rpc('get_note_uploader_info', {
-          note_object_id: note.id
-        })
+        .rpc('get_note_uploader_info', { note_object_id: note.id })
 
       if (uploaderError) {
         console.error('Blad pobierania danych udostepniajacego notatke:', uploaderError)
@@ -406,7 +402,6 @@ export const useNotes = () => {
       const uploaderRow = ((uploaderRows || [])[0] || null) as NoteUploaderInfoRow | null
       note.shared_by_label = formatUploaderLabel(note.is_owner, uploaderRow, note.uploaded_by)
     }))
-
   }
 
   const getNote = (id: string) => {

--- a/app/composables/useNotes.ts
+++ b/app/composables/useNotes.ts
@@ -380,7 +380,7 @@ export const useNotes = () => {
         visibility: noteVisibility,
         title: dbFile.name,
         content: existingNote?.content || '',
-        preview: existingNote?.preview || 'Ładowanie podglądu...',
+        preview: existingNote?.preview || '',
         updated_at: existingNote?.updated_at || dbFile.created_at,
         color: noteColor,
         user_role: role,
@@ -407,79 +407,6 @@ export const useNotes = () => {
       note.shared_by_label = formatUploaderLabel(note.is_owner, uploaderRow, note.uploaded_by)
     }))
 
-    const fileNameByOwner = new Map<string, Map<string, string>>()
-    const ownerIds = [...new Set(notes.value.map(note => note.uploaded_by).filter(Boolean))]
-
-    await Promise.all(ownerIds.map(async (ownerId: string) => {
-      const { data: storageList, error: storageListError } = await supabase.storage
-        .from('files')
-        .list(`notes/${ownerId}`, {
-          limit: 1000,
-          offset: 0,
-          sortBy: { column: 'name', order: 'asc' }
-        })
-
-      if (storageListError || !storageList) {
-        console.error(`Błąd listowania plików notatek dla użytkownika ${ownerId}:`, storageListError)
-        fileNameByOwner.set(ownerId, new Map())
-        return
-      }
-
-      const safeEntries = storageList
-        .filter(file => Boolean(file.id))
-        .map(file => [file.id as string, file.name] as const)
-
-      fileNameByOwner.set(ownerId, new Map(safeEntries))
-    }))
-
-    await Promise.all(notes.value.map(async (note) => {
-      const ownerMap = fileNameByOwner.get(note.uploaded_by || '')
-      const fileName = ownerMap?.get(note.id)
-      if (!fileName) {
-        note.preview = 'Brak podglądu treści'
-        return
-      }
-
-      const storagePath = `notes/${note.uploaded_by}/${fileName}`
-
-      let text: string | null = null
-
-      const { data: signedData, error: signedError } = await supabase.storage
-        .from('files')
-        .createSignedUrl(storagePath, 60)
-
-      if (!signedError && signedData?.signedUrl) {
-        try {
-          const response = await fetch(signedData.signedUrl, { cache: 'no-store' })
-          if (response.ok) {
-            text = await response.text()
-          }
-        } catch (error) {
-          console.error('Błąd pobierania podglądu przez signed URL:', error)
-        }
-      }
-
-      if (text === null) {
-        const { data: fileData, error: downloadError } = await supabase.storage
-          .from('files')
-          .download(storagePath)
-
-        if (downloadError || !fileData) {
-          note.preview = 'Brak podglądu treści'
-          return
-        }
-
-        text = await fileData.text()
-      }
-
-      const h1Title = extractFirstH1(text)
-      if (h1Title) {
-        note.title = h1Title
-      }
-
-      note.content = text
-      note.preview = extractPreview(text)
-    }))
   }
 
   const getNote = (id: string) => {

--- a/app/pages/dashboard/notes/[id].vue
+++ b/app/pages/dashboard/notes/[id].vue
@@ -1,7 +1,4 @@
 <script setup lang="ts">
-import { computed, ref, onMounted, onBeforeUnmount, onDeactivated, watch } from 'vue'
-import { useRouter, useRoute, onBeforeRouteLeave } from 'vue-router'
-import { useNotes } from '~/composables/useNotes'
 
 interface LoadedNotePayload {
     id: string
@@ -23,13 +20,12 @@ definePageMeta({
 
 const route = useRoute()
 const router = useRouter()
-const { getNote, saveNote: saveNoteToStore, fetchNotes, fetchNoteById } = useNotes()
+const { getNote, saveNote: saveNoteToStore, fetchNoteById } = useNotes()
 
 const noteId = ref(String(route.params.id))
 const title = ref('Ladowanie...')
 const content = ref<string | undefined>(undefined)
 const isSaving = ref(false)
-const isLoading = ref(true)
 const hasUnsavedChanges = ref(false)
 const lastSavedTitle = ref('')
 const lastSavedContent = ref('')
@@ -39,8 +35,35 @@ const canEdit = ref(false)
 const accessMessage = ref('')
 const noteGroupLabel = ref('')
 const sharedByLabel = ref('')
-const isFetchPending = ref(false)
-const showFloatingActions = computed(() => canEdit.value && !isLoading.value && !isFetchPending.value && !accessMessage.value)
+const currentNoteId = computed(() => String(route.params.id))
+
+const { status } = useLazyAsyncData(
+    () => `note-${currentNoteId.value}`,
+    async () => {
+        noteId.value = currentNoteId.value
+        try {
+            const payload = await fetchNoteById(currentNoteId.value)
+            if (!payload) {
+                setErrorState('Nie udalo sie zaladowac danych notatki.')
+                return
+            }
+            applyLoadedNote(payload)
+        } catch (error: any) {
+            const message = error.message || ''
+            if (message.includes('Nie masz dostepu') || message.includes('Brak autoryzacji')) {
+                setErrorState('Nie nalezysz do grupy tej notatki lub nie masz do niej dostepu.')
+            } else if (message.includes('nie istnieje') || message.includes('Nie znaleziono')) {
+                setErrorState('Notatka nie istnieje albo zostala usunieta.')
+            } else {
+                setErrorState(`Wystapil blad podczas ladowania notatki: ${message}`)
+            }
+        }
+    },
+    { server: false, watch: [currentNoteId] }
+)
+
+const isLoading = computed(() => status.value === 'pending')
+const showFloatingActions = computed(() => canEdit.value && !isLoading.value && !accessMessage.value)
 
 const releaseViewportLocks = () => {
     if (import.meta.server) return
@@ -131,41 +154,8 @@ const setErrorState = (message: string) => {
     hasUnsavedChanges.value = false
 }
 
-const loadNote = async () => {
-    isLoading.value = true
-    noteId.value = String(route.params.id)
-    isFetchPending.value = true
-
-    try {
-        await fetchNotes()
-        const payload = await fetchNoteById(noteId.value)
-
-        if (!payload) {
-            setErrorState('Nie udalo sie zaladowac danych notatki.')
-            return
-        }
-
-        applyLoadedNote(payload)
-    } catch (error: any) {
-        console.error('Blad ladowania notatki:', error)
-
-        const message = error.message || ''
-        if (message.includes('Nie masz dostepu') || message.includes('Brak autoryzacji')) {
-            setErrorState('Nie nalezysz do grupy tej notatki lub nie masz do niej dostepu.')
-        } else if (message.includes('nie istnieje') || message.includes('Nie znaleziono')) {
-            setErrorState('Notatka nie istnieje albo zostala usunieta.')
-        } else {
-            setErrorState(`Wystapil blad podczas ladowania notatki: ${message}`)
-        }
-    } finally {
-        isLoading.value = false
-        isFetchPending.value = false
-    }
-}
-
-onMounted(async () => {
+onMounted(() => {
     releaseViewportLocks()
-    await loadNote()
 })
 
 onBeforeRouteLeave(() => {
@@ -178,11 +168,6 @@ onBeforeUnmount(() => {
 
 onDeactivated(() => {
     releaseViewportLocks()
-})
-
-watch(() => route.params.id, async (newId, oldId) => {
-    if (String(newId) === String(oldId)) return
-    await loadNote()
 })
 
 watch(content, (newContent) => {
@@ -290,7 +275,7 @@ const saveNote = async () => {
         </UDashboardNavbar>
 
         <UDashboardPanelContent class="relative flex h-full flex-col overflow-y-auto bg-white p-0 pb-24 dark:bg-gray-900">
-            <div v-if="isLoading || isFetchPending" class="flex flex-1 items-center justify-center gap-2 text-gray-500 dark:text-gray-400">
+            <div v-if="isLoading" class="flex flex-1 items-center justify-center gap-2 text-gray-500 dark:text-gray-400">
                 <UIcon name="i-lucide-loader-2" class="h-5 w-5 animate-spin" />
                 <span>Ladowanie notatki...</span>
             </div>

--- a/app/pages/dashboard/notes/index.vue
+++ b/app/pages/dashboard/notes/index.vue
@@ -230,7 +230,6 @@ const extractUploaderName = (label: string) => {
 	return label.replace(/\s*\([^)]+\)\s*$/, '').trim()
 }
 
-// Mapowanie klas gradientów (Nuxt UI 3 color mapping helpers)
 const colorMap: Record<NoteColor, string> = {
 	blue: 'bg-blue-500/10 text-blue-600 dark:bg-blue-400/10 dark:text-blue-400 border-blue-200 dark:border-blue-900',
 	emerald: 'bg-emerald-500/10 text-emerald-600 dark:bg-emerald-400/10 dark:text-emerald-400 border-emerald-200 dark:border-emerald-900',
@@ -238,6 +237,15 @@ const colorMap: Record<NoteColor, string> = {
 	amber: 'bg-amber-500/10 text-amber-600 dark:bg-amber-400/10 dark:text-amber-400 border-amber-200 dark:border-amber-900',
 	rose: 'bg-rose-500/10 text-rose-600 dark:bg-rose-400/10 dark:text-rose-400 border-rose-200 dark:border-rose-900',
 	orange: 'bg-orange-500/10 text-orange-600 dark:bg-orange-400/10 dark:text-orange-400 border-orange-200 dark:border-orange-900'
+}
+
+const accentMap: Record<NoteColor, string> = {
+	blue: 'bg-blue-500',
+	emerald: 'bg-emerald-500',
+	purple: 'bg-purple-500',
+	amber: 'bg-amber-500',
+	rose: 'bg-rose-500',
+	orange: 'bg-orange-500'
 }
 </script>
 
@@ -314,101 +322,93 @@ const colorMap: Record<NoteColor, string> = {
 						Brak notatek w sekcji {{ section.label }}.
 					</div>
 
-					<div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-5">
-						<div v-for="note in section.notes" :key="note.id" class="group relative h-[270px]">
-							<UCard :class="[
-								'absolute inset-0 grid [grid-template-rows:auto_1fr_auto] cursor-pointer bg-white dark:bg-gray-900 ring-1 ring-gray-200 dark:ring-gray-800 shadow-sm hover:shadow-md hover:ring-primary-500/50 transform-gpu scale-100 hover:scale-100 active:scale-100 transition-[box-shadow,ring-color,background-color] duration-200 overflow-hidden rounded-xl',
-								isSelectionMode && isNoteSelected(note.id) ? 'ring-2 ring-primary-500' : ''
-							]" :ui="{ header: 'p-4 pb-2', body: 'px-4 pt-1 pb-2 h-[98px] overflow-hidden', footer: 'px-4 py-2.5 border-t border-gray-100 dark:border-gray-800' }"
-								@click="handleCardClick(note.id)">
-								<template #header>
-									<div class="flex items-start justify-between gap-3">
-										<div v-if="isSelectionMode" class="pt-1" @click.stop>
-											<UCheckbox :model-value="isNoteSelected(note.id)"
-												@update:model-value="setNoteSelection(note.id, !!$event)" />
+					<div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4">
+						<div
+							v-for="note in section.notes"
+							:key="note.id"
+							:class="[
+								'group cursor-pointer rounded-xl border bg-white dark:bg-gray-900 shadow-sm hover:shadow-md transition-all duration-200 overflow-hidden flex flex-col',
+								isSelectionMode && isNoteSelected(note.id)
+									? 'border-primary-400 dark:border-primary-500 ring-2 ring-primary-400/30'
+									: 'border-gray-200 dark:border-gray-800 hover:border-gray-300 dark:hover:border-gray-700'
+							]"
+							@click="handleCardClick(note.id)"
+						>
+							<div class="h-1 w-full shrink-0" :class="accentMap[note.color || 'blue']" />
+
+							<div class="p-4 flex flex-col gap-3 flex-1">
+								<div class="flex items-start gap-3">
+									<div v-if="isSelectionMode" class="pt-0.5 shrink-0" @click.stop>
+										<UCheckbox :model-value="isNoteSelected(note.id)"
+											@update:model-value="setNoteSelection(note.id, !!$event)" />
+									</div>
+									<div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border"
+										:class="colorMap[note.color || 'blue']">
+										<UIcon name="i-lucide-file-text" class="h-[18px] w-[18px] shrink-0" />
+									</div>
+									<div class="flex-1 min-w-0">
+										<div class="mb-1.5" @click.stop>
+											<UButton size="xs" color="neutral" variant="outline" :class="[
+												'shrink-0 font-semibold transition-all duration-150',
+												note.visibility === 'shared'
+													? 'border-emerald-300 bg-emerald-50 text-emerald-700 hover:bg-emerald-100 dark:border-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'
+													: 'border-sky-300 bg-sky-50 text-sky-700 hover:bg-sky-100 dark:border-sky-700 dark:bg-sky-900/40 dark:text-sky-300'
+											]" :disabled="isSelectionMode || !note.is_owner" @click.stop="handleToggleVisibility(note)">
+												{{ note.visibility === 'shared' ? 'Sh' : 'Ps' }}
+											</UButton>
 										</div>
-										<div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg border"
-											:class="colorMap[note.color || 'blue']">
-											<UIcon name="i-lucide-file-text" class="h-[18px] w-[18px] shrink-0" />
+										<div v-if="isEditingTitle === note.id" class="flex gap-1">
+											<UInput v-model="editingTitleValue" class="flex-1" size="xs" color="primary"
+												autofocus @click.stop @keydown.enter="saveTitle(note)"
+												@keydown.esc.stop="isEditingTitle = null" />
+											<UButton icon="i-lucide-check" color="success" size="xs" variant="ghost"
+												@click.stop="saveTitle(note)" />
 										</div>
-										<div class="flex-1 min-w-0">
-											<div class="flex items-center justify-between gap-2 mb-1" @click.stop>
-												<UButton size="xs" color="neutral" variant="outline" :class="[
-													'shrink-0 font-semibold transition-all duration-150 hover:shadow-sm',
-													note.visibility === 'shared'
-														? 'border-emerald-300 bg-emerald-50 text-emerald-700 hover:bg-emerald-100 hover:text-emerald-800 dark:border-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300 dark:hover:bg-emerald-900/60'
-														: 'border-sky-300 bg-sky-50 text-sky-700 hover:bg-sky-100 hover:text-sky-800 dark:border-sky-700 dark:bg-sky-900/40 dark:text-sky-300 dark:hover:bg-sky-900/60'
-												]" :disabled="isSelectionMode || !note.is_owner" @click.stop="handleToggleVisibility(note)"
-													title="Zmień typ notatki Personal/Shared">
-													{{ note.visibility === 'shared' ? 'Sh' : 'Ps' }}
-												</UButton>
-											</div>
-											<div v-if="isEditingTitle === note.id"
-												class="w-full flex gap-1 -mt-1 -ml-1">
-												<UInput v-model="editingTitleValue" class="flex-1" size="xs"
-													color="primary" autofocus @click.stop
-													@keydown.enter="saveTitle(note)"
-													@keydown.esc.stop="isEditingTitle = null" />
-												<UButton icon="i-lucide-check" color="success" size="xs" variant="ghost"
-													@click.stop="saveTitle(note)" />
-											</div>
-											<div v-else class="flex items-center justify-between w-full group/title">
-												<h3 class="font-semibold text-gray-900 dark:text-white truncate"
-													@click.stop="startEditingTitle(note)">{{ note.title }}</h3>
-												<UButton v-if="!isSelectionMode && note.can_edit"
-													icon="i-lucide-pen-line" color="neutral" variant="ghost" size="xs"
-													class="opacity-0 group-hover/title:opacity-100 transition-opacity ml-1 shrink-0"
-													@click.stop="startEditingTitle(note)"
-													title="Edytuj przypiętą nazwę" />
-											</div>
-											<div class="mt-1 flex flex-wrap gap-1">
-												<span v-if="note.group_name"
-													class="inline-flex items-center rounded-md border border-gray-200 dark:border-gray-700 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-gray-600 dark:text-gray-300">
-													{{ note.group_name }}
-												</span>
-												<span class="inline-flex items-center gap-1 rounded-md border border-blue-200 bg-blue-50 px-1.5 py-0.5 text-[10px] leading-none text-blue-700 dark:border-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
-													<UIcon name="i-lucide-mail" class="h-[11px] w-[11px] shrink-0" />
-													{{ extractUploaderName(note.shared_by_label) }}
-												</span>
-												<span v-if="extractUploaderRole(note.shared_by_label)"
-													class="inline-flex items-center gap-1 rounded-md border border-amber-200 bg-amber-50 px-1.5 py-0.5 text-[10px] leading-none font-medium text-amber-700 dark:border-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
-													<UIcon name="i-lucide-user-round" class="h-[11px] w-[11px] shrink-0" />
-													{{ extractUploaderRole(note.shared_by_label) }}
-												</span>
-											</div>
+										<div v-else class="flex items-start justify-between w-full group/title gap-1">
+											<h3 class="font-semibold text-gray-900 dark:text-white text-sm leading-snug line-clamp-2"
+												@click.stop="startEditingTitle(note)">{{ note.title }}</h3>
+											<UButton v-if="!isSelectionMode && note.can_edit" icon="i-lucide-pen-line"
+												color="neutral" variant="ghost" size="xs"
+												class="opacity-0 group-hover/title:opacity-100 transition-opacity shrink-0"
+												@click.stop="startEditingTitle(note)" />
 										</div>
 									</div>
-								</template>
-
-								<div class="h-full w-full overflow-hidden relative">
-									<p
-										class="text-gray-500 dark:text-gray-400 text-sm leading-relaxed whitespace-normal break-words font-sans overflow-hidden [display:-webkit-box] [-webkit-line-clamp:5] [-webkit-box-orient:vertical] max-h-[98px]">
-										{{ note.preview }}
-									</p>
 								</div>
 
-								<template #footer>
-									<div
-										class="relative z-10 flex items-center justify-between w-full text-xs font-medium text-gray-400">
-										<div
-											class="flex items-center gap-1.5 opacity-80 group-hover:opacity-100 transition-opacity">
-											<UIcon name="i-lucide-clock" class="h-[12px] w-[12px] shrink-0" />
-											{{ formatDate(note.updated_at) }}
-										</div>
-										<div class="flex items-center gap-0.5">
-											<UButton v-if="!isSelectionMode" icon="i-heroicons-sparkles" color="primary"
-												variant="ghost" size="xs"
-												class="opacity-70 group-hover:opacity-100 transition-opacity z-10 shrink-0"
-												@click.stop="openQuizForNote(note.id)"
-												title="Wygeneruj quiz z tej notatki" />
-											<UButton v-if="!isSelectionMode && note.is_owner" icon="i-lucide-trash"
-												color="error" variant="ghost" size="xs"
-												class="opacity-70 group-hover:opacity-100 transition-opacity cursor-pointer z-10 shrink-0"
-												@click.stop="handleDeleteNote(note.id)" title="Usuń notatkę" />
-										</div>
-									</div>
-								</template>
-							</UCard>
+								<div class="flex flex-wrap gap-1">
+									<span v-if="note.group_name"
+										class="inline-flex items-center rounded-md border border-gray-200 dark:border-gray-700 px-1.5 py-0.5 text-[10px] uppercase tracking-wide text-gray-500 dark:text-gray-400">
+										{{ note.group_name }}
+									</span>
+									<span
+										class="inline-flex items-center gap-1 rounded-md border border-blue-200 bg-blue-50 px-1.5 py-0.5 text-[10px] leading-none text-blue-700 dark:border-blue-800 dark:bg-blue-900/30 dark:text-blue-300">
+										<UIcon name="i-lucide-mail" class="h-[11px] w-[11px] shrink-0" />
+										{{ extractUploaderName(note.shared_by_label) }}
+									</span>
+									<span v-if="extractUploaderRole(note.shared_by_label)"
+										class="inline-flex items-center gap-1 rounded-md border border-amber-200 bg-amber-50 px-1.5 py-0.5 text-[10px] leading-none font-medium text-amber-700 dark:border-amber-800 dark:bg-amber-900/30 dark:text-amber-300">
+										<UIcon name="i-lucide-user-round" class="h-[11px] w-[11px] shrink-0" />
+										{{ extractUploaderRole(note.shared_by_label) }}
+									</span>
+								</div>
+							</div>
+
+							<div class="px-4 py-2.5 border-t border-gray-100 dark:border-gray-800 flex items-center justify-between">
+								<div class="flex items-center gap-1.5 text-xs text-gray-400 opacity-80 group-hover:opacity-100 transition-opacity">
+									<UIcon name="i-lucide-clock" class="h-[12px] w-[12px] shrink-0" />
+									{{ formatDate(note.updated_at) }}
+								</div>
+								<div class="flex items-center gap-0.5">
+									<UButton v-if="!isSelectionMode" icon="i-heroicons-sparkles" color="primary"
+										variant="ghost" size="xs"
+										class="opacity-70 group-hover:opacity-100 transition-opacity shrink-0"
+										@click.stop="openQuizForNote(note.id)" title="Wygeneruj quiz z tej notatki" />
+									<UButton v-if="!isSelectionMode && note.is_owner" icon="i-lucide-trash" color="error"
+										variant="ghost" size="xs"
+										class="opacity-70 group-hover:opacity-100 transition-opacity shrink-0"
+										@click.stop="handleDeleteNote(note.id)" title="Usuń notatkę" />
+								</div>
+							</div>
 						</div>
 					</div>
 				</section>

--- a/app/pages/dashboard/notes/index.vue
+++ b/app/pages/dashboard/notes/index.vue
@@ -1,4 +1,4 @@
-<script setup lang="ts">
+﻿<script setup lang="ts">
 import type { NoteColor, NoteItem } from '~/composables/useNotes'
 
 definePageMeta({
@@ -351,15 +351,18 @@ const accentMap: Record<NoteColor, string> = {
 											<button
 												v-if="note.is_owner && !isSelectionMode"
 												:class="[
-													'inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-[11px] font-semibold leading-none transition-all duration-150 cursor-pointer',
+													'group/vis inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-[11px] font-semibold leading-none transition-all duration-150 cursor-pointer hover:ring-1',
 													note.visibility === 'shared'
-														? 'border-emerald-300 bg-emerald-50 text-emerald-700 hover:bg-emerald-100 dark:border-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300 dark:hover:bg-emerald-900/60'
-														: 'border-sky-300 bg-sky-50 text-sky-700 hover:bg-sky-100 dark:border-sky-700 dark:bg-sky-900/40 dark:text-sky-300 dark:hover:bg-sky-900/60'
+														? 'border-emerald-300 bg-emerald-50 text-emerald-700 hover:bg-emerald-100 hover:ring-emerald-400/50 dark:border-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300 dark:hover:bg-emerald-900/60'
+														: 'border-sky-300 bg-sky-50 text-sky-700 hover:bg-sky-100 hover:ring-sky-400/50 dark:border-sky-700 dark:bg-sky-900/40 dark:text-sky-300 dark:hover:bg-sky-900/60'
 												]"
 												title="Kliknij aby zmienić widoczność"
 												@click.stop="handleToggleVisibility(note)"
 											>
-												<UIcon :name="note.visibility === 'shared' ? 'i-lucide-users' : 'i-lucide-lock'" class="h-3 w-3 shrink-0" />
+												<span class="relative h-3 w-3 shrink-0">
+													<UIcon :name="note.visibility === 'shared' ? 'i-lucide-users' : 'i-lucide-lock'" class="absolute inset-0 h-3 w-3 transition-opacity duration-150 group-hover/vis:opacity-0" />
+													<UIcon name="i-lucide-arrow-left-right" class="absolute inset-0 h-3 w-3 opacity-0 transition-opacity duration-150 group-hover/vis:opacity-100" />
+												</span>
 												{{ note.visibility === 'shared' ? 'Udostępniona' : 'Prywatna' }}
 											</button>
 											<span

--- a/app/pages/dashboard/notes/index.vue
+++ b/app/pages/dashboard/notes/index.vue
@@ -1,7 +1,4 @@
 <script setup lang="ts">
-import { computed, ref, onMounted } from 'vue'
-import { useRouter } from 'vue-router'
-import { useNotes } from '~/composables/useNotes'
 import type { NoteColor, NoteItem } from '~/composables/useNotes'
 
 definePageMeta({
@@ -16,7 +13,23 @@ const targetNoteId = ref<string | null>(null)
 const userGroups = ref<any[]>([])
 const selectedGroupId = ref<string>('')
 const isFetchingGroups = ref(false)
-const isLoadingNotes = ref(true)
+
+const { status: fetchStatus } = useLazyAsyncData('user-notes', fetchNotes, { server: false })
+const isLoadingNotes = computed(() => fetchStatus.value === 'pending')
+
+onMounted(() => {
+	if (import.meta.client) {
+		document.documentElement.classList.remove('overflow-hidden')
+		document.body.classList.remove('overflow-hidden')
+		document.documentElement.removeAttribute('data-scroll-locked')
+		document.body.removeAttribute('data-scroll-locked')
+		document.documentElement.style.overflow = ''
+		document.body.style.overflow = ''
+		document.body.style.position = ''
+		document.body.style.width = ''
+		document.body.style.paddingRight = ''
+	}
+})
 
 const openGroupSelectModal = async (noteId: string) => {
 	targetNoteId.value = noteId
@@ -44,27 +57,6 @@ const confirmGroupSelection = async () => {
 		console.error(error)
 	}
 }
-
-onMounted(async () => {
-	try {
-		if (import.meta.client) {
-			document.documentElement.classList.remove('overflow-hidden')
-			document.body.classList.remove('overflow-hidden')
-			document.documentElement.removeAttribute('data-scroll-locked')
-			document.body.removeAttribute('data-scroll-locked')
-			document.documentElement.style.overflow = ''
-			document.body.style.overflow = ''
-			document.body.style.position = ''
-			document.body.style.width = ''
-			document.body.style.paddingRight = ''
-		}
-
-		isLoadingNotes.value = true
-		await fetchNotes()
-	} finally {
-		isLoadingNotes.value = false
-	}
-})
 
 const isEditingTitle = ref<string | null>(null)
 const editingTitleValue = ref('')

--- a/app/pages/dashboard/notes/index.vue
+++ b/app/pages/dashboard/notes/index.vue
@@ -347,34 +347,13 @@ const accentMap: Record<NoteColor, string> = {
 										<UIcon name="i-lucide-file-text" class="h-[18px] w-[18px] shrink-0" />
 									</div>
 									<div class="flex-1 min-w-0">
-										<div class="mb-1.5" @click.stop>
-											<button
-												v-if="note.is_owner && !isSelectionMode"
-												:class="[
-													'group/vis inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-[11px] font-semibold leading-none transition-all duration-150 cursor-pointer hover:ring-1',
-													note.visibility === 'shared'
-														? 'border-emerald-300 bg-emerald-50 text-emerald-700 hover:bg-emerald-100 hover:ring-emerald-400/50 dark:border-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300 dark:hover:bg-emerald-900/60'
-														: 'border-sky-300 bg-sky-50 text-sky-700 hover:bg-sky-100 hover:ring-sky-400/50 dark:border-sky-700 dark:bg-sky-900/40 dark:text-sky-300 dark:hover:bg-sky-900/60'
-												]"
-												title="Kliknij aby zmienić widoczność"
-												@click.stop="handleToggleVisibility(note)"
-											>
-												<span class="relative h-3 w-3 shrink-0">
-													<UIcon :name="note.visibility === 'shared' ? 'i-lucide-users' : 'i-lucide-lock'" class="absolute inset-0 h-3 w-3 transition-opacity duration-150 group-hover/vis:opacity-0" />
-													<UIcon name="i-lucide-arrow-left-right" class="absolute inset-0 h-3 w-3 opacity-0 transition-opacity duration-150 group-hover/vis:opacity-100" />
-												</span>
-												{{ note.visibility === 'shared' ? 'Udostępniona' : 'Prywatna' }}
-												<UIcon name="i-lucide-pencil" class="h-2.5 w-2.5 shrink-0 ml-0.5 opacity-30 group-hover/vis:opacity-80 transition-opacity" />
-											</button>
-											<span
-												v-else
-												:class="[
-													'inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-[11px] font-medium leading-none select-none',
-													note.visibility === 'shared'
-														? 'border-emerald-200 bg-emerald-50/60 text-emerald-600 dark:border-emerald-800 dark:bg-emerald-900/20 dark:text-emerald-400'
-														: 'border-gray-200 bg-gray-50 text-gray-500 dark:border-gray-700 dark:bg-gray-800/50 dark:text-gray-400'
-												]"
-											>
+										<div class="mb-1.5">
+											<span :class="[
+												'inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-[11px] font-medium leading-none select-none',
+												note.visibility === 'shared'
+													? 'border-emerald-200 bg-emerald-50/60 text-emerald-600 dark:border-emerald-800 dark:bg-emerald-900/20 dark:text-emerald-400'
+													: 'border-gray-200 bg-gray-50 text-gray-500 dark:border-gray-700 dark:bg-gray-800/50 dark:text-gray-400'
+											]">
 												<UIcon :name="note.visibility === 'shared' ? 'i-lucide-users' : 'i-lucide-lock'" class="h-3 w-3 shrink-0" />
 												{{ note.visibility === 'shared' ? 'Udostępniona' : 'Prywatna' }}
 											</span>
@@ -421,6 +400,12 @@ const accentMap: Record<NoteColor, string> = {
 									{{ formatDate(note.updated_at) }}
 								</div>
 								<div class="flex items-center gap-0.5">
+									<UButton v-if="!isSelectionMode && note.is_owner"
+										:icon="note.visibility === 'shared' ? 'i-lucide-users' : 'i-lucide-lock'"
+										color="neutral" variant="ghost" size="xs"
+										class="opacity-70 group-hover:opacity-100 transition-opacity shrink-0"
+										:title="note.visibility === 'shared' ? 'Zmień na prywatną' : 'Udostępnij'"
+										@click.stop="handleToggleVisibility(note)" />
 									<UButton v-if="!isSelectionMode" icon="i-heroicons-sparkles" color="primary"
 										variant="ghost" size="xs"
 										class="opacity-70 group-hover:opacity-100 transition-opacity shrink-0"

--- a/app/pages/dashboard/notes/index.vue
+++ b/app/pages/dashboard/notes/index.vue
@@ -15,7 +15,7 @@ const selectedGroupId = ref<string>('')
 const isFetchingGroups = ref(false)
 
 const { status: fetchStatus } = useLazyAsyncData('user-notes', fetchNotes, { server: false })
-const isLoadingNotes = computed(() => fetchStatus.value === 'pending')
+const isLoadingNotes = computed(() => fetchStatus.value === 'pending' || fetchStatus.value === 'idle')
 
 onMounted(() => {
 	if (import.meta.client) {
@@ -179,7 +179,8 @@ const handleDeleteSelectedNotes = async () => {
 
 const handleCardClick = (id: string) => {
 	if (isSelectionMode.value) {
-		toggleNoteSelection(id)
+		const note = notes.value.find(n => n.id === id)
+		if (note?.is_owner) toggleNoteSelection(id)
 		return
 	}
 
@@ -327,7 +328,10 @@ const accentMap: Record<NoteColor, string> = {
 							v-for="note in section.notes"
 							:key="note.id"
 							:class="[
-								'group cursor-pointer rounded-xl border bg-white dark:bg-gray-900 shadow-sm hover:shadow-md transition-all duration-200 overflow-hidden flex flex-col',
+								'group rounded-xl border bg-white dark:bg-gray-900 shadow-sm transition-all duration-200 overflow-hidden flex flex-col',
+								isSelectionMode && !note.is_owner
+									? 'cursor-default opacity-50'
+									: 'cursor-pointer hover:shadow-md',
 								isSelectionMode && isNoteSelected(note.id)
 									? 'border-primary-400 dark:border-primary-500 ring-2 ring-primary-400/30'
 									: 'border-gray-200 dark:border-gray-800 hover:border-gray-300 dark:hover:border-gray-700'
@@ -338,7 +342,7 @@ const accentMap: Record<NoteColor, string> = {
 
 							<div class="p-4 flex flex-col gap-3 flex-1">
 								<div class="flex items-start gap-3">
-									<div v-if="isSelectionMode" class="pt-0.5 shrink-0" @click.stop>
+									<div v-if="isSelectionMode && note.is_owner" class="pt-0.5 shrink-0" @click.stop>
 										<UCheckbox :model-value="isNoteSelected(note.id)"
 											@update:model-value="setNoteSelection(note.id, !!$event)" />
 									</div>

--- a/app/pages/dashboard/notes/index.vue
+++ b/app/pages/dashboard/notes/index.vue
@@ -364,6 +364,7 @@ const accentMap: Record<NoteColor, string> = {
 													<UIcon name="i-lucide-arrow-left-right" class="absolute inset-0 h-3 w-3 opacity-0 transition-opacity duration-150 group-hover/vis:opacity-100" />
 												</span>
 												{{ note.visibility === 'shared' ? 'Udostępniona' : 'Prywatna' }}
+												<UIcon name="i-lucide-pencil" class="h-2.5 w-2.5 shrink-0 ml-0.5 opacity-30 group-hover/vis:opacity-80 transition-opacity" />
 											</button>
 											<span
 												v-else

--- a/app/pages/dashboard/notes/index.vue
+++ b/app/pages/dashboard/notes/index.vue
@@ -348,14 +348,32 @@ const accentMap: Record<NoteColor, string> = {
 									</div>
 									<div class="flex-1 min-w-0">
 										<div class="mb-1.5" @click.stop>
-											<UButton size="xs" color="neutral" variant="outline" :class="[
-												'shrink-0 font-semibold transition-all duration-150',
-												note.visibility === 'shared'
-													? 'border-emerald-300 bg-emerald-50 text-emerald-700 hover:bg-emerald-100 dark:border-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300'
-													: 'border-sky-300 bg-sky-50 text-sky-700 hover:bg-sky-100 dark:border-sky-700 dark:bg-sky-900/40 dark:text-sky-300'
-											]" :disabled="isSelectionMode || !note.is_owner" @click.stop="handleToggleVisibility(note)">
-												{{ note.visibility === 'shared' ? 'Sh' : 'Ps' }}
-											</UButton>
+											<button
+												v-if="note.is_owner && !isSelectionMode"
+												:class="[
+													'inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-[11px] font-semibold leading-none transition-all duration-150 cursor-pointer',
+													note.visibility === 'shared'
+														? 'border-emerald-300 bg-emerald-50 text-emerald-700 hover:bg-emerald-100 dark:border-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300 dark:hover:bg-emerald-900/60'
+														: 'border-sky-300 bg-sky-50 text-sky-700 hover:bg-sky-100 dark:border-sky-700 dark:bg-sky-900/40 dark:text-sky-300 dark:hover:bg-sky-900/60'
+												]"
+												title="Kliknij aby zmienić widoczność"
+												@click.stop="handleToggleVisibility(note)"
+											>
+												<UIcon :name="note.visibility === 'shared' ? 'i-lucide-users' : 'i-lucide-lock'" class="h-3 w-3 shrink-0" />
+												{{ note.visibility === 'shared' ? 'Udostępniona' : 'Prywatna' }}
+											</button>
+											<span
+												v-else
+												:class="[
+													'inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-[11px] font-medium leading-none select-none',
+													note.visibility === 'shared'
+														? 'border-emerald-200 bg-emerald-50/60 text-emerald-600 dark:border-emerald-800 dark:bg-emerald-900/20 dark:text-emerald-400'
+														: 'border-gray-200 bg-gray-50 text-gray-500 dark:border-gray-700 dark:bg-gray-800/50 dark:text-gray-400'
+												]"
+											>
+												<UIcon :name="note.visibility === 'shared' ? 'i-lucide-users' : 'i-lucide-lock'" class="h-3 w-3 shrink-0" />
+												{{ note.visibility === 'shared' ? 'Udostępniona' : 'Prywatna' }}
+											</span>
 										</div>
 										<div v-if="isEditingTitle === note.id" class="flex gap-1">
 											<UInput v-model="editingTitleValue" class="flex-1" size="xs" color="primary"


### PR DESCRIPTION

- Notatki pojawiają się od razu po pobraniu listy plików — dane uploadera (imię/rola) ładują się w tle bez blokowania widoku
- `isLoadingNotes` uwzględnia teraz status `idle`, co eliminuje błysk "Brak notatek" przed startem fetcha


- Kliknięcie karty cudzej notatki w trybie zaznaczania nie dodaje jej do selekcji
- Checkbox nie renderuje się przy notatkach, których użytkownik nie jest właścicielem
- Cudze notatki są wizualnie wyszarzone (`opacity-50`, `cursor-default`) w trybie zaznaczania